### PR TITLE
Fix heading with bold text producing malformed output

### DIFF
--- a/src/slackify_markdown/slackify.py
+++ b/src/slackify_markdown/slackify.py
@@ -10,6 +10,8 @@ from slackify_markdown.utils import escape_specials
 # Todo: Clean code before release.
 class SlackifyMarkdown(RendererHTML):
 
+    _in_heading = False
+
     SUPPORTED_TOKENS = [
         "text",
         "inline",
@@ -112,6 +114,7 @@ class SlackifyMarkdown(RendererHTML):
         options: Dict[str, Any],
         env: Dict[str, Any],
     ) -> str:
+        self.__class__._in_heading = True
         return "*"
 
     def heading_close(
@@ -121,6 +124,7 @@ class SlackifyMarkdown(RendererHTML):
         options: Dict[str, Any],
         env: Dict[str, Any],
     ) -> str:
+        self.__class__._in_heading = False
         return "*\n\n"
 
     def strong_open(
@@ -130,6 +134,8 @@ class SlackifyMarkdown(RendererHTML):
         options: Dict[str, Any],
         env: Dict[str, Any],
     ) -> str:
+        if self._in_heading:
+            return ""
         return "*"
 
     def strong_close(
@@ -139,6 +145,8 @@ class SlackifyMarkdown(RendererHTML):
         options: Dict[str, Any],
         env: Dict[str, Any],
     ) -> str:
+        if self._in_heading:
+            return ""
         return "*"
 
     def em_open(

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -178,6 +178,12 @@ def test_headings():
     assert slackify_markdown(mrkdown) == slack
 
 
+def test_heading_with_bold():
+    assert slackify_markdown("### **Step 1**: Description here") == "*Step 1: Description here*\n\n"
+    assert slackify_markdown("### **Step 1**") == "*Step 1*\n\n"
+    assert slackify_markdown("# **Test**: text") == "*Test: text*\n\n"
+
+
 def test_bold():
     mrkdown = "**bold text**"
     slack = "*bold text*\n"


### PR DESCRIPTION
## Summary

- Fixes #10 — headings containing bold text (e.g. `### **Step 1**: Description here`) produced malformed Slack mrkdwn output like `**Step 1*: Description here*`
- Both headings and bold map to `*` in Slack mrkdwn, so nested bold inside a heading creates duplicate/mismatched `*` markers
- Suppresses `strong_open`/`strong_close` markers when inside a heading context, since the heading wrapper already provides bold formatting

## Before / After

| Markdown | Before (broken) | After (fixed) |
|---|---|---|
| `### **Step 1**: Description here` | `**Step 1*: Description here*` | `*Step 1: Description here*` |
| `### **Step 1**` | `**Step 1**` | `*Step 1*` |
| `# **Test**: text` | `**Test*: text*` | `*Test: text*` |

## Test plan

- [x] Added `test_heading_with_bold` covering all 3 reproduction cases from the issue
- [x] All 48 tests pass (47 existing + 1 new)
- [x] Verified standalone bold (`**Bold**` → `*Bold*`) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)