### PR TITLE
Use instance variable for _in_heading state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slackify_markdown"
-version = "0.2.1"
+version = "0.2.2"
 description = "Convert markdown to Slack-compatible formatting"
 readme = "readme.md"
 authors = [

--- a/src/slackify_markdown/slackify.py
+++ b/src/slackify_markdown/slackify.py
@@ -10,8 +10,6 @@ from slackify_markdown.utils import escape_specials
 # Todo: Clean code before release.
 class SlackifyMarkdown(RendererHTML):
 
-    _in_heading = False
-
     SUPPORTED_TOKENS = [
         "text",
         "inline",
@@ -54,6 +52,7 @@ class SlackifyMarkdown(RendererHTML):
     def __init__(self, markdown_text: str):
         super().__init__()
         self.markdown_text = markdown_text
+        self._in_heading = False
 
     # this is not correctly done, we need to check in an deopth for children,
     # the library offers allowed tokens/tags. Move to that instead of this :), todo.
@@ -114,7 +113,7 @@ class SlackifyMarkdown(RendererHTML):
         options: Dict[str, Any],
         env: Dict[str, Any],
     ) -> str:
-        self.__class__._in_heading = True
+        self._in_heading = True
         return "*"
 
     def heading_close(
@@ -124,7 +123,7 @@ class SlackifyMarkdown(RendererHTML):
         options: Dict[str, Any],
         env: Dict[str, Any],
     ) -> str:
-        self.__class__._in_heading = False
+        self._in_heading = False
         return "*\n\n"
 
     def strong_open(

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -182,6 +182,12 @@ def test_heading_with_bold():
     assert slackify_markdown("### **Step 1**: Description here") == "*Step 1: Description here*\n\n"
     assert slackify_markdown("### **Step 1**") == "*Step 1*\n\n"
     assert slackify_markdown("# **Test**: text") == "*Test: text*\n\n"
+    assert slackify_markdown("### Normal and **bold**") == "*Normal and bold*\n\n"
+
+
+def test_heading_with_italic():
+    assert slackify_markdown("### *emphasized*") == "*_emphasized_*\n\n"
+    assert slackify_markdown("### ***bold italic***") == "*_bold italic_*\n\n"
 
 
 def test_bold():


### PR DESCRIPTION
## Summary

- Moves `_in_heading` from a class variable to an instance variable initialized in `__init__`
- Fixes thread-safety issue: concurrent renders would interfere with each other via shared class state
- Fixes sticky-state bug: if rendering threw between `heading_open` and `heading_close`, the flag would stay `True` for all future renders

## Test plan

- [x] All 48 existing tests pass
- [x] No behavioral change — instance state is sufficient since the same renderer instance processes the full token stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)