### PR TITLE
chore: bump version to 0.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slackify_markdown"
-version = "0.2.3"
+version = "0.2.4"
 description = "Convert markdown to Slack-compatible formatting"
 readme = "readme.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "slackify-markdown"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "markdown-it-py" },


### PR DESCRIPTION
## Summary

- Bumps `version` in `pyproject.toml` from `0.2.3` to `0.2.4`.
- Refreshes `uv.lock` to track the new version.

## What ships in 0.2.4

This release includes the nested-list spacing/indent overhaul merged in #20:

- Adds proper 4-space indent per nest level for bullet and ordered lists.
- Adds bullet hierarchy: `•` / `◦` / `▪` for depths 1 / 2 / 3+ (matches Slack's native rendering).
- Fixes multi-blank-line cascades from deeply nested list closes and blockquotes (was producing 2+ blank lines between blocks; now exactly one).
- Preserves multi-blank-line content inside fenced code blocks verbatim.
- Adds 10 new edge-case tests + 1 full-document integration test (60 total).
- Adds `docs/architecture.md` documenting the renderer pipeline and the STX-sentinel cap mechanism.

## Test plan
- [x] `pytest tests/` — 60/60 pass locally